### PR TITLE
initial nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,17 @@
+{
+  description = "A very basic flake";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/43cc2746c6ef3e0cbe80e043bf7521eff17c7236";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let pkgs = nixpkgs.legacyPackages.${system}; in
+        {
+          devShells.default = import ./shell.nix { inherit pkgs; };
+        }
+      );
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,24 @@
+{ pkgs ? import <nixpkgs> { } }:
+with pkgs;
+mkShell {
+  buildInputs = [
+    nim
+    nimlsp
+    nodejs
+  ];
+
+  # Aliases work from project root in the ./nim folder
+  shellHook = ''
+    alias karax-start="./bin/transpileMarkdown && \
+./nimbledeps/bin/karun -r -w ./src/website.nim"
+
+    alias tailwind-start="npx tailwindcss -i ./assets/prestyles.css \
+-o ./assets/styles.css --watch"
+
+    alias karax-recompile="cd $PROJECT_ROOT; ./bin/transpileMarkdown && \
+nim js --out:./app.js ./src/website.nim"
+
+    alias nim-compile="nim c --outDir:bin --verbosity:0 --listfullpaths \
+./transpileMarkdown.nim"
+  '';
+}

--- a/shell.nix
+++ b/shell.nix
@@ -15,7 +15,7 @@ mkShell {
     alias tailwind-start="npx tailwindcss -i ./assets/prestyles.css \
 -o ./assets/styles.css --watch"
 
-    alias karax-recompile="cd $PROJECT_ROOT; ./bin/transpileMarkdown && \
+    alias karax-recompile="./bin/transpileMarkdown && \
 nim js --out:./app.js ./src/website.nim"
 
     alias nim-compile="nim c --outDir:bin --verbosity:0 --listfullpaths \


### PR DESCRIPTION
Only covers the basic developer shell and some helpful aliases.  Could cover a build later on as well.  Uses nix flakes, which are reproducible down to the package channel checkout.